### PR TITLE
Update time_precision to use 'ms'

### DIFF
--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -293,7 +293,7 @@ InfluxdbBackend.prototype.httpPOST = function (points) {
   if (!points.length) { return; }
 
   var self = this,
-      query= {u: self.user, p: self.pass, time_precision: 'm'};
+      query= {u: self.user, p: self.pass, time_precision: 'ms'};
 
   self.logDebug(function () {
     return 'Sending ' + points.length + ' different points via HTTP';


### PR DESCRIPTION
InfluxDB has deprecated the use of 'm' for `time_precision`. We need to use 'ms' now.

```
[WARN] (github.com/influxdb/influxdb/api/http.TimePrecisionFromString:280) time_precision=m will be disabled in future release, use time_precision=ms instead
```
