### PR TITLE
Gauges with zero value are not being sent

### DIFF
--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -142,7 +142,7 @@ InfluxdbBackend.prototype.processFlush = function (timestamp, metrics) {
     var value = gauges[key],
         k = key + '.gauge';
 
-    if (value) {
+    if (!isNaN(parseFloat(value)) && isFinite(value)) {
       points.push(self.assembleEvent(k, [{value: value, time: timestamp}]));
     }
   }


### PR DESCRIPTION
Hey,

I added a small fix for allowing gauges to be sent if their value is 0.

Could you also release a new version with the latest changes?

Cheers!
