### PR TITLE
Added SSL support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ You can configure the following settings in your StatsD config file.
   influxdb: {
     host: '127.0.0.1',   // InfluxDB host. (default 127.0.0.1)
     port: 8086,          // InfluxDB port. (default 8086)
+    ssl: false,          // InfluxDB is hosted over SSL. (default false)
     database: 'dbname',  // InfluxDB database instance. (required)
     username: 'user',    // InfluxDB database username. (required)
     password: 'pass',    // InfluxDB database password. (required)

--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -12,6 +12,7 @@
  * influxdb: {
  *   host: '127.0.0.1',   // InfluxDB host. (default 127.0.0.1)
  *   port: 8086,          // InfluxDB port. (default 8086)
+ *   ssl: false,          // InfluxDB is hosted over SSL. (default false)
  *   database: 'dbname',  // InfluxDB database instance. (required)
  *   username: 'user',    // InfluxDB database username. (required)
  *   password: 'pass',    // InfluxDB database password. (required)
@@ -29,7 +30,8 @@
  */
 var util = require('util'),
     querystring = require('querystring'),
-    http = require('http');
+    http = require('http'),
+    https = require('https');
 
 function InfluxdbBackend(startupTime, config, events) {
   var self = this;
@@ -46,6 +48,7 @@ function InfluxdbBackend(startupTime, config, events) {
 
   self.host = self.defaultHost;
   self.port = self.defaultPort;
+  self.protocol = http;
   self.flushEnable = self.defaultFlushEnable;
   self.proxyEnable = self.defaultProxyEnable;
   self.proxySuffix = self.defaultProxySuffix;
@@ -57,6 +60,10 @@ function InfluxdbBackend(startupTime, config, events) {
     self.user = config.influxdb.username;
     self.pass = config.influxdb.password;
     self.database = config.influxdb.database;
+
+    if (config.influxdb.ssl) {
+      self.protocol = https;
+    }
 
     if (config.influxdb.flush) {
       self.flushEnable = config.influxdb.flush.enable;
@@ -293,10 +300,11 @@ InfluxdbBackend.prototype.httpPOST = function (points) {
   if (!points.length) { return; }
 
   var self = this,
-      query= {u: self.user, p: self.pass, time_precision: 'ms'};
+      query = {u: self.user, p: self.pass, time_precision: 'ms'},
+      protocolName = self.protocol == http ? 'HTTP' : 'HTTPS';
 
   self.logDebug(function () {
-    return 'Sending ' + points.length + ' different points via HTTP';
+    return 'Sending ' + points.length + ' different points via ' + protocolName;
   });
 
   var options = {
@@ -307,13 +315,13 @@ InfluxdbBackend.prototype.httpPOST = function (points) {
     agent: false // Is it okay to use "undefined" here? (keep-alive)
   };
 
-  var req = http.request(options);
+  var req = self.protocol.request(options);
 
   req.on('response', function (res) {
     var status = res.statusCode;
 
     if (status !== 200) {
-      self.log('HTTP Error: ' + status);
+      self.log(protocolName + ' Error: ' + status);
     }
   });
 


### PR DESCRIPTION
This change simply adds support for a `ssl` config option, to allow for when InfluxDB is being hosted over SSL.

The way it's implemented is that when `ssl` is set to `true`, the `https` module is used for requests to InfluxDB, instead of the `http` module.

Thanks a lot for the library, it's working great.
