### PR TITLE
fixed issue with precision

### DIFF
--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -300,7 +300,7 @@ InfluxdbBackend.prototype.httpPOST = function (points) {
   if (!points.length) { return; }
 
   var self = this,
-      query = {u: self.user, p: self.pass, time_precision: 'ms'},
+      query = {u: self.user, p: self.pass, time_precision: 'm'},
       protocolName = self.protocol == http ? 'HTTP' : 'HTTPS';
 
   self.logDebug(function () {


### PR DESCRIPTION
Fix to stop HTTP 400 responses from influxdb due to the use of ms rather than m when posting precision
