### PR TITLE
Fixed histogram data breaking data flushes

### DIFF
--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -157,6 +157,23 @@ InfluxdbBackend.prototype.processFlush = function (timestamp, metrics) {
   for (key in timerData) {
     var timerMetrics = timerData[key];
 
+    // Try to add histogram data, if it is there:
+    if (timerMetrics.histogram) {
+      var histoMetrics = timerMetrics.histogram
+        , histoKey;
+
+      for (histoKey in histoMetrics) {
+        var value = histoMetrics[histoKey],
+          k = key + '.timer.histogram.' + histoKey;
+
+        points.push(self.assembleEvent(k, [{value: value, time: timestamp}]));
+      }
+
+      // Delete here so it isn't iterated over later:
+      delete timerMetrics.histogram;
+    }
+
+    // Iterate over normal metrics:
     for (timerKey in timerMetrics) {
       var value = timerMetrics[timerKey],
           k = key + '.timer' + '.' + timerKey;


### PR DESCRIPTION
If statsd is configured to attach histogram data to one of its timers, then this backend will generate a poorly-formatted request, causing influxdb to reject it with a 400 response.

This fixes that by checking for histogram data in timers, and unrolling them into data points like: "*.timer.histogram.bin_*"

BTW: Thanks for this project. It's been a lifesaver. :)