### PR TITLE
Pass on internal statsd_metrics data and generate additional backend metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ You can configure the following settings in your StatsD config file.
       flushInterval: 1000  // Flush interval for the internal buffer.
                            // (default 1000)
     },
-    includeStatsdMetrics: false // Send statsd metrics to InfluxDB. (default false)
+    includeStatsdMetrics: false, // Send internal statsd metrics to InfluxDB. (default false)
+    includeInfluxdbMetrics: false // Send internal backend metrics to InfluxDB. (default false)
+                                  // Requires includeStatsdMetrics to be enabled.
   }
 }
 ```
@@ -300,6 +302,16 @@ The payload of a HTTP request might look like this:
   }
 ]
 ```
+## Backend Metrics
+
+The following internal metrics are calculated for each flush:
+
+- `statsd.influxdbStats.flush_time` - Time taken to process a complete flush in ms. Excluding the asynchronous HTTP Post.
+- `statsd.influxdbStats.http_response_time` - Response time in ms of the InfluxDB HTTP endpoint when POSTing data.
+- `statsd.influxdbStats.payload_size` - The size in bytes of the JSON payload.
+- `statsd.influxdbStats.num_stats` - The number of metrics sent to InfluxDB in the last flush.
+
+This is added to the set of internal statsd metrics. If both `influxdb.includeStatsdMetrics` and `influxdb.includeInfluxdbMetrics` are enabled, then these will be sent to InfluxDB when using the flush strategy.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ The payload of a HTTP request might look like this:
   }
 ]
 ```
+
 ## Backend Metrics
 
 The following internal metrics are calculated for each flush:
@@ -311,7 +312,9 @@ The following internal metrics are calculated for each flush:
 - `statsd.influxdbStats.payload_size` - The size in bytes of the JSON payload.
 - `statsd.influxdbStats.num_stats` - The number of metrics sent to InfluxDB in the last flush.
 
-This is added to the set of internal statsd metrics. If both `influxdb.includeStatsdMetrics` and `influxdb.includeInfluxdbMetrics` are enabled, then these will be sent to InfluxDB when using the flush strategy.
+These are added to the set of internal statsd metrics. If both `influxdb.includeStatsdMetrics` and `influxdb.includeInfluxdbMetrics` are enabled, then these will be sent to InfluxDB when using the flush strategy.
+
+The internal metrics can also can be viewed using the `stats` command on the [StatsD TCP Admin Interface](https://github.com/etsy/statsd/blob/master/docs/admin_interface.md)
 
 ## Contributing
 

--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -172,6 +172,9 @@ InfluxdbBackend.prototype.processFlush = function (timestamp, metrics) {
   }
 
   for (key in gauges) {
+    /* Do not include statsd gauges. */
+    if (!self.includeStatsdMetrics && key.match(statsdMetricsRegExp)) { continue; }
+
     var value = gauges[key],
         k = key + '.gauge';
 

--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -146,6 +146,7 @@ InfluxdbBackend.prototype.processFlush = function (timestamp, metrics) {
         }
         return ret;
       }(metrics.sets),
+      statsdMetricsRegExp = new RegExp('^'+self.prefixStats),
       key, timerKey;
 
   /* Convert timestamp from seconds to milliseconds. */
@@ -153,7 +154,7 @@ InfluxdbBackend.prototype.processFlush = function (timestamp, metrics) {
 
   for (key in counters) {
     /* Do not include statsd counters. */
-    if (!self.includeStatsdMetrics && key.match(/^statsd\./)) { continue; }
+    if (!self.includeStatsdMetrics && key.match(statsdMetricsRegExp)) { continue; }
 
     var value = counters[key],
         k = key + '.counter';

--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -46,6 +46,7 @@ function InfluxdbBackend(startupTime, config, events) {
   self.defaultProxyEnable = false;
   self.defaultProxySuffix = 'raw';
   self.defaultProxyFlushInterval = 1000;
+  self.prefixStats = config.prefixStats !== undefined ? config.prefixStats : "statsd";
 
   self.host = self.defaultHost;
   self.port = self.defaultPort;
@@ -136,6 +137,7 @@ InfluxdbBackend.prototype.processFlush = function (timestamp, metrics) {
       counters = metrics.counters,
       gauges = metrics.gauges,
       timerData = metrics.timer_data,
+      statsdMetrics = metrics.statsd_metrics,
       points = [],
       sets  = function (vals) {
         var ret = {};
@@ -202,6 +204,17 @@ InfluxdbBackend.prototype.processFlush = function (timestamp, metrics) {
           k = key + '.timer' + '.' + timerKey;
 
       points.push(self.assembleEvent(k, [{value: value, time: timestamp}]));
+    }
+  }
+
+  if (self.includeStatsdMetrics) {
+    for (key in statsdMetrics) {
+      var value = statsdMetrics[key],
+          k = prefixStats + '.' + key;
+
+      if (!isNaN(parseFloat(value)) && isFinite(value)) {
+        points.push(self.assembleEvent(k, [{value: value, time: timestamp}]));
+      }
     }
   }
 

--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -25,7 +25,9 @@
  *     flushInterval: 1000  // Flush interval for the internal buffer.
  *                          // (default 1000)
  *   },
- *   includeStatsdMetrics: false // Send statsd metrics to InfluxDB. (default false)
+ *   includeStatsdMetrics: false, // Send internal statsd metrics to InfluxDB. (default false)
+ *   includeInfluxdbMetrics: false // Send internal backend metrics to InfluxDB. (default false)
+ *                                 // Requires includeStatsdMetrics to be enabled.
  * }
  *
  */
@@ -39,6 +41,7 @@ function InfluxdbBackend(startupTime, config, events) {
 
   self.debug = config.debug;
   self.registry = {};
+  self.influxdbStats = {};
 
   self.defaultHost = '127.0.0.1';
   self.defaultPort = 8086;
@@ -56,6 +59,7 @@ function InfluxdbBackend(startupTime, config, events) {
   self.proxySuffix = self.defaultProxySuffix;
   self.proxyFlushInterval = self.defaultProxyFlushInterval;
   self.includeStatsdMetrics = false;
+  self.includeInfluxdbMetrics = false;
 
   if (config.influxdb) {
     self.host = config.influxdb.host || self.defaultHost;
@@ -64,7 +68,8 @@ function InfluxdbBackend(startupTime, config, events) {
     self.pass = config.influxdb.password;
     self.database = config.influxdb.database;
     self.includeStatsdMetrics = config.influxdb.includeStatsdMetrics;
-
+    self.includeInfluxdbMetrics = config.influxdb.includeInfluxdbMetrics;
+    
     if (config.influxdb.ssl) {
       self.protocol = https;
     }
@@ -108,6 +113,11 @@ function InfluxdbBackend(startupTime, config, events) {
   return true;
 }
 
+function millisecondsSince(start) {
+	diff = process.hrtime(start);
+	return diff[0] * 1000 + diff[1] / 1000000;
+}
+
 InfluxdbBackend.prototype.log = function (msg) {
   util.log('[influxdb] ' + msg);
 }
@@ -138,6 +148,7 @@ InfluxdbBackend.prototype.processFlush = function (timestamp, metrics) {
       gauges = metrics.gauges,
       timerData = metrics.timer_data,
       statsdMetrics = metrics.statsd_metrics,
+      statsdMetricsRegExp = new RegExp('^'+self.prefixStats),
       points = [],
       sets  = function (vals) {
         var ret = {};
@@ -146,7 +157,7 @@ InfluxdbBackend.prototype.processFlush = function (timestamp, metrics) {
         }
         return ret;
       }(metrics.sets),
-      statsdMetricsRegExp = new RegExp('^'+self.prefixStats),
+      startTime = process.hrtime(),
       key, timerKey;
 
   /* Convert timestamp from seconds to milliseconds. */
@@ -212,6 +223,14 @@ InfluxdbBackend.prototype.processFlush = function (timestamp, metrics) {
   }
 
   if (self.includeStatsdMetrics) {
+    // Include backend metrics for the previous flush
+    if (self.includeInfluxdbMetrics) {
+      statsdMetrics['influxdbStats.flush_time'] = self.influxdbStats.flushTime;
+      statsdMetrics['influxdbStats.http_response_time'] = self.influxdbStats.httpResponseTime;
+      statsdMetrics['influxdbStats.payload_size'] = self.influxdbStats.payloadSize;
+      statsdMetrics['influxdbStats.num_stats'] = self.influxdbStats.numStats;
+    }
+    
     for (key in statsdMetrics) {
       var value = statsdMetrics[key],
           k = prefixStats + '.' + key;
@@ -223,6 +242,7 @@ InfluxdbBackend.prototype.processFlush = function (timestamp, metrics) {
   }
 
   self.httpPOST(points);
+  self.influxdbStats.flushTime = millisecondsSince(startTime);
 }
 
 InfluxdbBackend.prototype.processPacket = function (packet, rinfo) {
@@ -358,11 +378,14 @@ InfluxdbBackend.prototype.httpPOST = function (points) {
 
   var self = this,
       query = {u: self.user, p: self.pass, time_precision: 'm'},
-      protocolName = self.protocol == http ? 'HTTP' : 'HTTPS';
+      protocolName = self.protocol == http ? 'HTTP' : 'HTTPS',
+      startTime;
 
   self.logDebug(function () {
     return 'Sending ' + points.length + ' different points via ' + protocolName;
   });
+  
+  self.influxdbStats.numStats = points.length;
 
   var options = {
     hostname: self.host,
@@ -373,10 +396,16 @@ InfluxdbBackend.prototype.httpPOST = function (points) {
   };
 
   var req = self.protocol.request(options);
+  
+  req.on('socket', function (res) {
+    startTime = process.hrtime();
+  });
 
   req.on('response', function (res) {
     var status = res.statusCode;
-
+    
+    self.influxdbStats.httpResponseTime = millisecondsSince(startTime);
+    
     if (status !== 200) {
       self.log(protocolName + ' Error: ' + status);
     }
@@ -386,14 +415,15 @@ InfluxdbBackend.prototype.httpPOST = function (points) {
     self.log(e);
   });
 
+  var payload = JSON.stringify(points)
+  self.influxdbStats.payloadSize = Buffer.byteLength(payload);
+  
   self.logDebug(function () {
-    var str = JSON.stringify(points),
-        size = (Buffer.byteLength(str) / 1024).toFixed(2);
-
+    var size = (self.influxdbStats.payloadSize / 1024).toFixed(2);
     return 'Payload size ' + size + ' KB';
   });
 
-  req.write(JSON.stringify(points));
+  req.write(payload);
   req.end();
 }
 

--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -109,6 +109,12 @@ function InfluxdbBackend(startupTime, config, events) {
       }
     });
   }
+  
+  events.on('status', function (writeCb) {
+    for (var stat in self.influxdbStats) {
+      writeCb(null, 'influxdb', stat, self.influxdbStats[stat]);
+    }
+  });
 
   return true;
 }


### PR DESCRIPTION
As discussed in #6, also gather `statsd_metrics` data from the StatsD backend interface and send to InfluxDB when using the flush strategy and `includeStatsdMetrics` is true.

Also the influxdb backend now generates`flush_time`, `http_response_time`, `payload_size` and `num_stats` metrics and sends these to InfluxDB if `includeInfluxdbMetrics` is true. These can also be seen via the TCP admin interface.