### PR TITLE
Updated regex name for statsd gauges.

### DIFF
--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -192,7 +192,7 @@ InfluxdbBackend.prototype.processFlush = function (timestamp, metrics) {
 
   for (key in gauges) {
     /* Do not include statsd gauges. */
-    if (!self.includeStatsdMetrics && key.match(statsdMetricsRegExp)) { continue; }
+    if (!self.includeStatsdMetrics && key.match(statsPrefixRegexp) { continue; }
 
     var value = gauges[key],
         k = key + '.gauge';


### PR DESCRIPTION
In commit d6df6cd102cf56facc475f075c7248412e0aea8c the `statsdMetricsRegExp` variable was removed. This pull request replaces the remaining usage of this variable with `statsPrefixRegexp`.