### PR TITLE
add missing parens from conditional

### DIFF
--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -192,7 +192,7 @@ InfluxdbBackend.prototype.processFlush = function (timestamp, metrics) {
 
   for (key in gauges) {
     /* Do not include statsd gauges. */
-    if (!self.includeStatsdMetrics && key.match(statsPrefixRegexp) { continue; }
+    if (!self.includeStatsdMetrics && key.match(statsPrefixRegexp)) { continue; }
 
     var value = gauges[key],
         k = key + '.gauge';

--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -241,7 +241,7 @@ InfluxdbBackend.prototype.processFlush = function (timestamp, metrics) {
     
     for (key in statsdMetrics) {
       var value = statsdMetrics[key],
-          k = prefixStats + '.' + key;
+          k = self.prefixStats + '.' + key;
 
       if (!isNaN(parseFloat(value)) && isFinite(value)) {
         points.push(self.assembleEvent(k, [{value: value, time: timestamp}]));


### PR DESCRIPTION
I'm super new influx and this particular backend however ran into an odd issue trying to get things started. When starting up using a slightly tweaked version of the example config the code was failing like so:

```
$ node stats.js sigsci.js
26 Mar 15:58:30 - reading config file: sigsci.js
26 Mar 15:58:30 - server is up

/Users/mbarczak/src/statsd/node_modules/statsd-influxdb-backend/lib/influxdb.js:195
    if (!self.includeStatsdMetrics && key.match(statsPrefixRegexp) { continue;
                                                                   ^
SyntaxError: Unexpected token {
    at Module._compile (module.js:439:25)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at loadBackend (/Users/mbarczak/src/statsd/stats.js:36:20)
    at /Users/mbarczak/src/statsd/stats.js:427:9
    at null.<anonymous> (/Users/mbarczak/src/statsd/lib/config.js:40:5)
    at emit (events.js:95:17)
```

Appears there was a missing parens on the if which is fixed in this patch.