### PR TITLE
Allow anoymous login

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ You can configure the following settings in your StatsD config file.
     version: 0.8,        // InfluxDB port. (default 0.8)
     ssl: false,          // InfluxDB is hosted over SSL. (default false)
     database: 'dbname',  // InfluxDB database instance. (required)
-    username: 'user',    // InfluxDB database username. (required)
-    password: 'pass',    // InfluxDB database password. (required)
+    username: 'user',    // InfluxDB database username. (required unless anom is true)
+    password: 'pass',    // InfluxDB database password. (required anom is true)
+    anom: true,
     flush: {
       enable: true       // Enable regular flush strategy. (default true)
     },

--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -128,8 +128,6 @@ function InfluxdbBackend(startupTime, config, events) {
       writeCb(null, 'influxdb', stat, self.influxdbStats[stat]);
     }
   });
-
-  return true;
 }
 
 function millisecondsSince(start) {
@@ -139,7 +137,7 @@ function millisecondsSince(start) {
 
 InfluxdbBackend.prototype.log = function (msg) {
   util.log('[influxdb] ' + msg);
-}
+};
 
 InfluxdbBackend.prototype.logDebug = function (msg) {
   if (this.debug) {
@@ -153,7 +151,7 @@ InfluxdbBackend.prototype.logDebug = function (msg) {
 
     util.log('[influxdb] (DEBUG) ' + string);
   }
-}
+};
 
 /**
  * Flush strategy handler
@@ -262,7 +260,7 @@ InfluxdbBackend.prototype.processFlush = function (timestamp, metrics) {
 
   self.httpPOST(points);
   self.influxdbStats.flushTime = millisecondsSince(startTime);
-}
+};
 
 InfluxdbBackend.prototype.processPacket = function (packet, rinfo) {
   var self = this,
@@ -322,7 +320,7 @@ InfluxdbBackend.prototype.processPacket = function (packet, rinfo) {
       }
     }
   }
-}
+};
 
 InfluxdbBackend.prototype.enqueue = function (type, ts, key, value) {
   var self = this;
@@ -334,7 +332,7 @@ InfluxdbBackend.prototype.enqueue = function (type, ts, key, value) {
   }
 
   self.registry[key].push({value: value, time: ts});
-}
+};
 
 InfluxdbBackend.prototype.flushQueue = function () {
   var self = this,
@@ -354,7 +352,7 @@ InfluxdbBackend.prototype.flushQueue = function () {
   self.httpPOST(points);
 
   self.logDebug('Queue flushed');
-}
+};
 
 
 InfluxdbBackend.prototype.clearRegistry = function () {
@@ -364,7 +362,7 @@ InfluxdbBackend.prototype.clearRegistry = function () {
   self.registry = {};
 
   return registry;
-}
+};
 
 InfluxdbBackend.prototype.assembleEvent_v08 = function (name, events) {
   var self = this;
@@ -389,7 +387,7 @@ InfluxdbBackend.prototype.assembleEvent_v08 = function (name, events) {
   }
 
   return payload;
-}
+};
 
 InfluxdbBackend.prototype.assembleEvent_v09 = function (name, events) {
   var self = this;
@@ -398,10 +396,10 @@ InfluxdbBackend.prototype.assembleEvent_v09 = function (name, events) {
     name: name,
     timestamp: events[0]['time'],
     fields: { value: events[0]['value'] }
-  }
+  };
 
   return payload;
-}
+};
 
 InfluxdbBackend.prototype.httpPOST_v08 = function (points) {
   /* Do not send if there are no points. */
@@ -456,7 +454,7 @@ InfluxdbBackend.prototype.httpPOST_v08 = function (points) {
 
   req.write(payload);
   req.end();
-}
+};
 
 InfluxdbBackend.prototype.httpPOST_v09 = function (points) {
   /* Do not send if there are no points. */
@@ -516,18 +514,18 @@ InfluxdbBackend.prototype.httpPOST_v09 = function (points) {
 
   req.write(payload);
   req.end();
-}
+};
 
 InfluxdbBackend.prototype.configCheck = function () {
   var self = this,
       success = true;
 
   /* Make sure the database name and credentials are configured. */
-  if (!self.user) {
+  if (!self.user && !self.anom) {
     self.log('Missing config option: username');
     success = false;
   }
-  if (!self.pass) {
+  if (!self.pass && !self.anom) {
     self.log('Missing config option: password');
     success = false;
   }
@@ -537,10 +535,10 @@ InfluxdbBackend.prototype.configCheck = function () {
   }
 
   return success;
-}
+};
 
 exports.init = function (startupTime, config, events) {
   var influxdb = new InfluxdbBackend(startupTime, config, events);
 
   return influxdb.configCheck();
-}
+};


### PR DESCRIPTION
Username and password are not mandatory for influxdb. We use it on our internal network so don't need authentication but the backend hard error on it. I've added an `anom` mode to allow using without username and password.