### PR TITLE
Support InfluxDB 0.9 line protocol

### DIFF
--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -462,7 +462,7 @@ InfluxdbBackend.prototype.httpPOST_v09 = function (points) {
   if (!points.length) { return; }
 
   var self = this,
-      query = {u: self.user, p: self.pass},
+      query = {u: self.user, p: self.pass, db: self.database},
       protocolName = self.protocol == http ? 'HTTP' : 'HTTPS',
       startTime;
 
@@ -500,16 +500,28 @@ InfluxdbBackend.prototype.httpPOST_v09 = function (points) {
     self.log(e);
   });
 
-  var payload = JSON.stringify({
-    database: self.database,
-    points: points
-  });
+  var points_to_payload = function(points) {
+    // {"database":"statsd","points":[{"measurement":"my.test.cnt,host=server1,name=abc.gauge","fields":{"value":56}}]}
+    lines = '';
+    for (p in points) {
+      p = points[p];
+      var l = p['measurement'] + ' value=' + p['fields']['value'];
+      lines += l + "\n";
+    }
+    return lines;
+  };
+
+  var payload = points_to_payload(points);
 
   self.influxdbStats.payloadSize = Buffer.byteLength(payload);
 
   self.logDebug(function () {
     var size = (self.influxdbStats.payloadSize / 1024).toFixed(2);
     return 'Payload size ' + size + ' KB';
+  });
+
+  self.logDebug(function () {
+    return "Payload: \n" + payload;
   });
 
   req.write(payload);


### PR DESCRIPTION
For influx 0.9, change protocol from JSON to line protocol, support tags in InfluxDB 0.9.