### PR TITLE
Allow connection pooling

### DIFF
--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -421,8 +421,7 @@ InfluxdbBackend.prototype.httpPOST_v08 = function (points) {
     hostname: self.host,
     port: self.port,
     path: '/db/' + self.database + '/series?' + querystring.stringify(query),
-    method: 'POST',
-    agent: false // Is it okay to use "undefined" here? (keep-alive)
+    method: 'POST'
   };
 
   var req = self.protocol.request(options);
@@ -439,6 +438,8 @@ InfluxdbBackend.prototype.httpPOST_v08 = function (points) {
     if (status !== 200) {
       self.log(protocolName + ' Error: ' + status);
     }
+	
+	res.on('data', function(){});
   });
 
   req.on('error', function (e, i) {
@@ -476,8 +477,7 @@ InfluxdbBackend.prototype.httpPOST_v09 = function (points) {
     hostname: self.host,
     port: self.port,
     path: '/write?' + querystring.stringify(query),
-    method: 'POST',
-    agent: false // Is it okay to use "undefined" here? (keep-alive)
+    method: 'POST'
   };
 
   var req = self.protocol.request(options);
@@ -494,6 +494,8 @@ InfluxdbBackend.prototype.httpPOST_v09 = function (points) {
     if (status >= 400) {
       self.log(protocolName + ' Error: ' + status);
     }
+	
+	res.on('data', function(){});
   });
 
   req.on('error', function (e, i) {


### PR DESCRIPTION
Allow connection pooling so that requests do not back up when the response time is slower than the flush interval. Handle response data events so that Node is aware we have consumed the response instead of waiting for a remote timeout (see http://stackoverflow.com/questions/15533448/node-js-http-request-problems-with-connection-pooling).

Graph showing the effects of this change (in addition to updating NodeJS from 0.10.26 to 0.12.7):
![before_after](https://cloud.githubusercontent.com/assets/9611672/10372212/ad08ae86-6dde-11e5-8d20-ddc81c327416.png)

