### PR TITLE
Influxdb0.9 line protocol and tags

### DIFF
--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -462,7 +462,7 @@ InfluxdbBackend.prototype.httpPOST_v09 = function (points) {
   if (!points.length) { return; }
 
   var self = this,
-      query = {u: self.user, p: self.pass},
+      query = {u: self.user, p: self.pass, db: self.database},
       protocolName = self.protocol == http ? 'HTTP' : 'HTTPS',
       startTime;
 
@@ -500,10 +500,28 @@ InfluxdbBackend.prototype.httpPOST_v09 = function (points) {
     self.log(e);
   });
 
-  var payload = JSON.stringify({
-    database: self.database,
-    points: points
-  });
+  var payload
+      , lines = [], totalPoint = 0
+  // http://www.sitepoint.com/javascript-fast-string-concatenation/
+  for (p in points) {
+    //metricname#tag1=v1,tag2=1.metrictype
+    var metricAndTags = points[p]['measurement']
+      .replace(/\s+/g, '_')
+      .replace(/\//g, '-')
+      .replace(/[^a-zA-Z_\-0-9\.#,=]/g, '')
+
+    metricAndTags = metricAndTags.split(/#(.+)\.([a-z]+)$/)
+
+    if (metricAndTags.length == 1) {
+      lines[totalPoint++] = `${metricAndTags[0]} value=${points[p]['fields']['value']}`
+      continue
+    }
+
+    if (metricAndTags.length >= 3) {
+      lines[totalPoint++] = `${metricAndTags[0]}.${metricAndTags[2]},${metricAndTags[1]} value=${points[p]['fields']['value']}`
+    }
+  }
+  payload = lines.join("\n")
 
   self.influxdbStats.payloadSize = Buffer.byteLength(payload);
 
@@ -525,6 +543,8 @@ InfluxdbBackend.prototype.configCheck = function () {
     self.log('Missing config option: database');
     success = false;
   }
+
+  self.log('Run with InfluxDB ' + self.version)
 
   return success;
 }


### PR DESCRIPTION
This does't require any chances on statsd site as other solution. It works by appending `tag` into metric name, and parse metric name to write tags.

First, disable sanity key checking on config.js of statsd. Then write metric in this format:

```
metricname#tag1=val1,tag2=val2:value|metrictype|@samplerate
```
