### PR TITLE
Suggested patch to allow 'host' tagging

### DIFF
--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -79,7 +79,11 @@ function InfluxdbBackend(startupTime, config, events) {
     if (config.influxdb.ssl) {
       self.protocol = https;
     }
-
+    
+    if (config.influxdb.host_tag) {
+      self.host_tag = config.influxdb.host_tag
+    }
+    
     if (config.influxdb.flush) {
       self.flushEnable = config.influxdb.flush.enable;
     }
@@ -399,7 +403,11 @@ InfluxdbBackend.prototype.assembleEvent_v09 = function (name, events) {
     measurement: name,
     fields: { value: events[0]['value'] }
   }
-
+  
+  if (self.host_tag) {
+    payload.fields.host = self.host_tag
+  }
+  
   return payload;
 }
 

--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -405,7 +405,8 @@ InfluxdbBackend.prototype.assembleEvent_v09 = function (name, events) {
   }
   
   if (self.host_tag) {
-    payload.fields.host = self.host_tag
+    payload.tags = {}
+    payload.tags.host = self.host_tag
   }
   
   return payload;

--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -16,6 +16,7 @@
  *   database: 'dbname',  // InfluxDB database instance. (required)
  *   username: 'user',    // InfluxDB database username.
  *   password: 'pass',    // InfluxDB database password.
+ *   host_tag: '',        // Append a 'host' tag to each measurement
  *   flush: {
  *     enable: true       // Enable regular flush strategy. (default true)
  *   },


### PR DESCRIPTION
This will allow for appending a 'host' tag when sending measurements to InfluxDB.

Useful when sending gauge metrics with the same name from multiple hosts.
