### PR TITLE
Support InfluxDB >= 0.11 with tags

### DIFF
--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -10,22 +10,23 @@
  * 'influxdb' hash defined in the main statsd config file:
  *
  * influxdb: {
- *   host: '127.0.0.1',   // InfluxDB host. (default 127.0.0.1)
- *   port: 8086,          // InfluxDB port. (default 8086)
- *   ssl: false,          // InfluxDB is hosted over SSL. (default false)
- *   database: 'dbname',  // InfluxDB database instance. (required)
- *   username: 'user',    // InfluxDB database username.
- *   password: 'pass',    // InfluxDB database password.
+ *   host: '127.0.0.1',            // InfluxDB host. (default 127.0.0.1)
+ *   port: 8086,                   // InfluxDB port. (default 8086)
+ *   ssl: false,                   // InfluxDB is hosted over SSL. (default false)
+ *   version: 0.8,                 // InfluxDB version. (default 0.8)
+ *   database: 'dbname',           // InfluxDB database instance. (required)
+ *   retentionPolicy: 'default'    // InfluxDB retention policy. (default default)
+ *   username: 'user',             // InfluxDB database username.
+ *   password: 'pass',             // InfluxDB database password.
  *   flush: {
- *     enable: true       // Enable regular flush strategy. (default true)
+ *     enable: true                // Enable regular flush strategy. (default true)
  *   },
  *   proxy: {
- *     enable: false,       // Enable the proxy strategy. (default false)
- *     suffix: 'raw',       // Metric name suffix. (default 'raw')
- *     flushInterval: 1000  // Flush interval for the internal buffer.
- *                          // (default 1000)
+ *     enable: false,              // Enable the proxy strategy. (default false)
+ *     suffix: 'raw',              // Metric name suffix. (default 'raw')
+ *     flushInterval: 1000         // Flush interval for the internal buffer. (default 1000)
  *   },
- *   includeStatsdMetrics: false, // Send internal statsd metrics to InfluxDB. (default false)
+ *   includeStatsdMetrics: false,  // Send internal statsd metrics to InfluxDB. (default false)
  *   includeInfluxdbMetrics: false // Send internal backend metrics to InfluxDB. (default false)
  *                                 // Requires includeStatsdMetrics to be enabled.
  * }
@@ -50,6 +51,7 @@ function InfluxdbBackend(startupTime, config, events) {
   self.defaultProxyEnable = false;
   self.defaultProxySuffix = 'raw';
   self.defaultProxyFlushInterval = 1000;
+  self.defaultRetentionPolicy = 'default';
 
   self.host = self.defaultHost;
   self.port = self.defaultPort;
@@ -72,6 +74,7 @@ function InfluxdbBackend(startupTime, config, events) {
     self.user = config.influxdb.username;
     self.pass = config.influxdb.password;
     self.database = config.influxdb.database;
+    self.retentionPolicy = config.influxdb.retentionPolicy || self.defaultRetentionPolicy;
     self.includeStatsdMetrics = config.influxdb.includeStatsdMetrics;
     self.includeInfluxdbMetrics = config.influxdb.includeInfluxdbMetrics;
 
@@ -90,7 +93,10 @@ function InfluxdbBackend(startupTime, config, events) {
     }
   }
 
-  if (self.version >= 0.9) {
+  if (self.version >= 0.11) {
+    self.assembleEvent = self.assembleEvent_v11;
+    self.httpPOST = self.httpPOST_v11;
+  } else if (self.version >= 0.9) {
     self.assembleEvent = self.assembleEvent_v09;
     self.httpPOST = self.httpPOST_v09;
   } else {
@@ -402,6 +408,19 @@ InfluxdbBackend.prototype.assembleEvent_v09 = function (name, events) {
   return payload;
 }
 
+InfluxdbBackend.prototype.assembleEvent_v11 = function (name, events) {
+  var self = this;
+
+  var name_parts = name.split('.');
+  var payload = name_parts[0];
+  for (var t=1; t<name_parts.length; t++) {
+    payload = payload + ",tag" + t + "=" + name_parts[t];
+  }
+  payload = payload + " value=" + events[0]['value'] + " " + events[0]['time']*1000000;
+
+  return payload;
+}
+
 InfluxdbBackend.prototype.httpPOST_v08 = function (points) {
   /* Do not send if there are no points. */
   if (!points.length) { return; }
@@ -504,6 +523,73 @@ InfluxdbBackend.prototype.httpPOST_v09 = function (points) {
     database: self.database,
     points: points
   });
+
+  self.influxdbStats.payloadSize = Buffer.byteLength(payload);
+
+  self.logDebug(function () {
+    var size = (self.influxdbStats.payloadSize / 1024).toFixed(2);
+    return 'Payload size ' + size + ' KB';
+  });
+
+  req.write(payload);
+  req.end();
+}
+
+InfluxdbBackend.prototype.httpPOST_v11 = function (points) {
+  /* Do not send it there are no points. */
+  if (!points.length) { return; }
+
+  var self = this,
+      query = {
+        db: self.database,
+        rp: self.retentionPolicy,
+        u: self.user,
+        p: self.pass
+      },
+      protocolName = self.protocol == http ? 'HTTP' : 'HTTPS',
+      startTime;
+
+  self.logDebug(function () {
+    return 'Sending ' + points.length + ' different points via ' + protocolName;
+  });
+
+  self.influxdbStats.numStats = points.length;
+
+  var options = {
+    hostname: self.host,
+    port: self.port,
+    path: '/write?' + querystring.stringify(query),
+    method: 'POST',
+    headers: {
+      'content-type': 'x-www-form-urlencoded'
+    },
+    agent: false
+  };
+
+  var req = self.protocol.request(options);
+
+  req.on('socket', function (res) {
+    startTime = process.hrtime();
+  });
+
+  req.on('response', function (res) {
+    var status = res.statusCode;
+
+    self.influxdbStats.httpResponseTime = millisecondsSince(startTime);
+
+    if (status >= 400) {
+      self.log(protocolName + ' Error: ' + status);
+    }
+  });
+
+  req.on('error', function (e, i) {
+    self.log(e);
+  });
+
+  var payload = points[0];
+  for (var t=1; t<points.length; t++) {
+    payload = payload + "\n" + points[t];
+  }
 
   self.influxdbStats.payloadSize = Buffer.byteLength(payload);
 


### PR DESCRIPTION
Per https://docs.influxdata.com/influxdb/v0.13/concepts/schema_and_data_layout/, it's better for InfluxDB to differentiate data with tags than with detailed measurement names.  Tags are indexed and InfluxDB does not allow merging data across measurements, so parsing and tagging as built in this PR provides the best balance of flexibility and performance with InfuxDB.  This change splits metrics like `appname.datacenter.hostname.requests:1|c` into:

```
name: appname
tag1: datacenter
tag2: hostname
tag3: requests
```

This has been tested against InfluxDB v0.13 in a high-volume production environment.
